### PR TITLE
首都大 → 都立大 に変更

### DIFF
--- a/home.html
+++ b/home.html
@@ -14,7 +14,7 @@
             </div>
         </header>
         <p>都立大生向け授業情報共有サイト</p>
-        <a href="http://tmu-minamiosawa.sakura.ne.jp/minamiosawa/rei.html" target="_blank">首都大南大沢</a><br>
+        <a href="http://tmu-minamiosawa.sakura.ne.jp/minamiosawa/rei.html" target="_blank">都立大南大沢</a><br>
         <br>
         <div class="links">
             <a href="http://tmu-minamiosawa.sakura.ne.jp/ishiike/mon.php" class="days">月曜日</a><br><br>


### PR DESCRIPTION
大学名が東京都立大学になったので、リンクの表記を変更しました。